### PR TITLE
Add 'inkludering' in bingo.json

### DIFF
--- a/src/bingo.json
+++ b/src/bingo.json
@@ -52,6 +52,8 @@
     "Tre innlegg faller på rad",
     "Noen gråter under ordensnominasjon",
     "«Vi er i rute»",
+    "«Inkludering»",
+    "«Vi må treffe bredere»",
     "Kandidater til gruppeansvarlig blir spurt om hvordan de skal representere andre komiteer enn sin egen"
   ]
 }


### PR DESCRIPTION
The last years, it has been a lot of talk of how we as a linjeforening needs to 'treffe bredere', 'treffe *alle* abakuler' and 'inkludering', especially of people not in a comitee.
Maybe the sentences should be refined, but the bingo should contain something about it. :)